### PR TITLE
Fix `java/io/IOException` class not found error

### DIFF
--- a/src/main/java/binaryeq/jmutator/ClassMutator.java
+++ b/src/main/java/binaryeq/jmutator/ClassMutator.java
@@ -48,11 +48,7 @@ public class ClassMutator {
         System.out.println("using default pitest mutators: org.pitest.mutationtest.engine.gregor.config.Mutator::newDefaults");
         final Collection<MethodMutatorFactory> mutators = Mutator.newDefaults();
 
-//        final DefaultMutationEngineConfiguration config = new DefaultMutationEngineConfiguration(i -> true, mutators);
-        final DefaultMutationEngineConfiguration config = new DefaultMutationEngineConfiguration(i -> {
-            System.err.println("methodFilter predicate called with " + i + " from class " + i.getOwningClass() + ".");     //DEBUG
-            return true;
-        }, mutators);
+        final DefaultMutationEngineConfiguration config = new DefaultMutationEngineConfiguration(i -> true, mutators);
         MutationEngine engine = new GregorMutationEngine(config);
         ClassByteArraySource byteSource = new FileClassByteArraySource(binDir);
         Mutater mutater = engine.createMutator(byteSource);


### PR DESCRIPTION
```
wtwhite@wtwhite-vuw-vm:~/code/jmutator$ time java -jar target/jmutator.jar -b data/original-jars/openjdk-11.0.19/commons-io-2.12.0 -m data/mutated-jars/openjdk-11.0.19/commons-io-2.12.0 -p '$n-$i.class' -j '$n-$i.json' -v
using default pitest mutators: org.pitest.mutationtest.engine.gregor.config.Mutator::newDefaults
Exception in thread "main" java.lang.IllegalArgumentException: Class not found in /home/wtwhite/code/jmutator/data/original-jars/openjdk-11.0.19/commons-io-2.12.0: java/io/IOException
	at binaryeq.jmutator.FileClassByteArraySource.getBytes(FileClassByteArraySource.java:25)
	at org.pitest.classinfo.ComputeClassWriter.typeInfo(ComputeClassWriter.java:188)
	at org.pitest.classinfo.ComputeClassWriter.getCommonSuperClass(ComputeClassWriter.java:71)
	at org.pitest.reloc.asm.SymbolTable.addMergedType(SymbolTable.java:1202)
	at org.pitest.reloc.asm.Frame.merge(Frame.java:1300)
	at org.pitest.reloc.asm.Frame.merge(Frame.java:1214)
	at org.pitest.reloc.asm.MethodWriter.computeAllFrames(MethodWriter.java:1611)
	at org.pitest.reloc.asm.MethodWriter.visitMaxs(MethodWriter.java:1547)
	at org.pitest.reloc.asm.MethodVisitor.visitMaxs(MethodVisitor.java:786)
	at org.pitest.reloc.asm.MethodVisitor.visitMaxs(MethodVisitor.java:786)
	at org.pitest.reloc.asm.MethodVisitor.visitMaxs(MethodVisitor.java:786)
	at org.pitest.reloc.asm.MethodVisitor.visitMaxs(MethodVisitor.java:786)
	at org.pitest.reloc.asm.tree.MethodNode.accept(MethodNode.java:767)
	at org.pitest.mutationtest.engine.gregor.blocks.BlockTrackingMethodDecorator.visitEnd(BlockTrackingMethodDecorator.java:49)
	at org.pitest.reloc.asm.ClassReader.readMethod(ClassReader.java:1518)
	at org.pitest.reloc.asm.ClassReader.accept(ClassReader.java:744)
	at org.pitest.reloc.asm.ClassReader.accept(ClassReader.java:424)
	at org.pitest.mutationtest.engine.gregor.GregorMutater.getMutation(GregorMutater.java:106)
	at binaryeq.jmutator.ClassMutator.mutateClassFiles(ClassMutator.java:63)
	at binaryeq.jmutator.Main.main(Main.java:50)

real	0m0.198s
user	0m0.343s
sys	0m0.055s
```

Strange that no one else seems to have hit this -- this is basically the same working example as @mmabdpr sent me (command line args `-b data/jars/commons-io-2.7 -m data/jars/commons-io-2.7.mutated -p "$n-$i.class" -j "$n-$i.json" -v`), except for a different project version. I can also repro the error with `commons-io-2.7`.