### PR TITLE
Automate NEQ2 creation

### DIFF
--- a/run-all.sh
+++ b/run-all.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [ -z "$JARS" ]
+then
+	echo "Must specify the jars folder with env var JARS"
+	exit 1
+fi
+
+# List latest compilable versions of each project into latest_project_versions.txt
+./select-project-versions.sh
+
+# I decided on this compiler version manually
+COMPILER="${COMPILER:-openjdk-11.0.19}"
+
+# Copy selected project versions to local dir
+mkdir -p "data/original-jars/$COMPILER"
+for f in `cat latest_project_versions.txt`; do echo $f; cp "$JARS/$COMPILER/$f" "data/original-jars/$COMPILER"; done
+
+# Generate mutated classes
+time for d in data/original-jars/$COMPILER/*; do echo $d; m=${d/original-/mutated-}; echo $m; mkdir -p $m && java -jar target/jmutator.jar -b $d -m $m -p '$n-$i.class' -j '$n-$i.json' -v >$m.stdout 2>$m.stderr; done
+
+# Convert JSON results to TSV
+time ./convert-json-to-tsv-faster.sh > NEQ2.tsv
+
+# Jar up classes
+time for d in jars/NEQ2/$COMPILER/*/; do echo $d; b=`basename ${d%/}`; echo $b; ( cd `dirname $d` && find $b -name '*.class' > $b.filelist && jar --create --file $b.jar @$b.filelist ) ; done

--- a/run-all.sh
+++ b/run-all.sh
@@ -6,15 +6,18 @@ then
 	exit 1
 fi
 
-# List latest compilable versions of each project into latest_project_versions.txt
+# List latest compilable versions of each project into latest_project_versions_with_tests.txt
 ./select-project-versions.sh
 
 # I decided on this compiler version manually
 COMPILER="${COMPILER:-openjdk-11.0.19}"
 
+# Find the subset of jars that actually exist (not all projects have buildable test jars)
+for f in `cat latest_project_versions_with_tests.txt`; do if [ -e "$JARS/$COMPILER/$f" ]; then echo $f; fi; done > actually_existing_latest_project_versions.txt
+
 # Extract selected project versions to local dir
 mkdir -p "jars/EQ/$COMPILER"
-for f in `cat latest_project_versions.txt`; do echo "$f"; d="jars/EQ/$COMPILER/${f%.jar}"; echo "$d"; mkdir -p "$d"; ( cd "$d" && unzip "$JARS/$COMPILER/$f" ); done
+for f in `cat actually_existing_latest_project_versions.txt`; do echo "$f"; d="jars/EQ/$COMPILER/${f%.jar}"; echo "$d"; mkdir -p "$d"; ( cd "$d" && unzip "$JARS/$COMPILER/$f" ); done
 
 # Generate mutated classes
 mvn package

--- a/run-all.sh
+++ b/run-all.sh
@@ -12,9 +12,9 @@ fi
 # I decided on this compiler version manually
 COMPILER="${COMPILER:-openjdk-11.0.19}"
 
-# Copy selected project versions to local dir
+# Extract selected project versions to local dir
 mkdir -p "jars/EQ/$COMPILER"
-for f in `cat latest_project_versions.txt`; do echo $f; cp "$JARS/$COMPILER/$f" "jars/EQ/$COMPILER"; done
+for f in `cat latest_project_versions.txt`; do echo "$f"; d="jars/EQ/$COMPILER/${f%.jar}"; echo "$d"; mkdir -p "$d"; ( cd "$d" && unzip "$JARS/$COMPILER/$f" ); done
 
 # Generate mutated classes
 mvn package

--- a/run-all.sh
+++ b/run-all.sh
@@ -17,6 +17,7 @@ mkdir -p "jars/EQ/$COMPILER"
 for f in `cat latest_project_versions.txt`; do echo $f; cp "$JARS/$COMPILER/$f" "jars/EQ/$COMPILER"; done
 
 # Generate mutated classes
+mvn package
 mkdir -p "jars/NEQ2/$COMPILER"
 time for d in jars/EQ/$COMPILER/*; do echo $d; m=${d/EQ/NEQ2}; echo $m; mkdir -p $m && java -jar target/jmutator.jar -b $d -m $m -p '$n-$i.class' -j '$n-$i.json' -v >$m.stdout 2>$m.stderr; done
 

--- a/run-all.sh
+++ b/run-all.sh
@@ -13,11 +13,12 @@ fi
 COMPILER="${COMPILER:-openjdk-11.0.19}"
 
 # Copy selected project versions to local dir
-mkdir -p "data/original-jars/$COMPILER"
-for f in `cat latest_project_versions.txt`; do echo $f; cp "$JARS/$COMPILER/$f" "data/original-jars/$COMPILER"; done
+mkdir -p "jars/EQ/$COMPILER"
+for f in `cat latest_project_versions.txt`; do echo $f; cp "$JARS/$COMPILER/$f" "jars/EQ/$COMPILER"; done
 
 # Generate mutated classes
-time for d in data/original-jars/$COMPILER/*; do echo $d; m=${d/original-/mutated-}; echo $m; mkdir -p $m && java -jar target/jmutator.jar -b $d -m $m -p '$n-$i.class' -j '$n-$i.json' -v >$m.stdout 2>$m.stderr; done
+mkdir -p "jars/NEQ2/$COMPILER"
+time for d in jars/EQ/$COMPILER/*; do echo $d; m=${d/EQ/NEQ2}; echo $m; mkdir -p $m && java -jar target/jmutator.jar -b $d -m $m -p '$n-$i.class' -j '$n-$i.json' -v >$m.stdout 2>$m.stderr; done
 
 # Convert JSON results to TSV
 time ./convert-json-to-tsv-faster.sh > NEQ2.tsv

--- a/select-project-versions.sh
+++ b/select-project-versions.sh
@@ -12,7 +12,7 @@ then
 	exit 1
 fi
 
-#for f in $JARS/*/*.jar; do echo ${f##*/}; done|sort|uniq > project_names.txt
+# Read project and jar names from dataset.json. Optimistically add test jars; later processing will need to filter out any that don't exist.
 jq -r '.[] | .name + "\t" + .jar' < "$DATASET" > project_names.txt
 perl -le 'sub svcmp($$) { my ($x, $y) = @_; return 0 if !@$x && !@$y; return -1 if !@$x; return 1 if !@$y; return ($x->[0] <=> $y->[0]) || svcmp([@$x[1..$#{$x}]], [@$y[1..$#{$y}]]); } sub getsv($) { my ($before, $sv, $after) = $_[0] =~ m|^(\S+)\t.+-([\d.]+)((?:-tests)?\.jar)$| or die "Cannot find semver in $_[0]"; return ([ split /\./, $sv ], "$after$before"); } my @lines = <>; chomp @lines; @lines = sort { my ($asv, $arest) = getsv($a); my ($bsv, $brest) = getsv($b); return ($arest cmp $brest) || svcmp($asv, $bsv); } @lines; for (my $i = 0; $i < @lines; ++$i) { print $lines[$i] if ($i == @lines - 1 || (getsv($lines[$i]))[1] ne (getsv($lines[$i + 1]))[1]); }' < project_names.txt > latest_project_versions.txt
 perl -lane 'print $F[1]; $F[1] =~ s|\.jar$|-tests.jar|; print $F[1]' < latest_project_versions.txt > latest_project_versions_with_tests.txt

--- a/select-project-versions.sh
+++ b/select-project-versions.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -z "$JARS" ]
+then
+	echo "Must specify the jars folder with env var JARS"
+	exit 1
+fi
+
+for f in $JARS/*/*.jar; do echo ${f##*/}; done|sort|uniq > project_names.txt
+perl -le 'sub svcmp($$) { my ($x, $y) = @_; return 0 if !@$x && !@$y; return -1 if !@$x; return 1 if !@$y; return ($x->[0] <=> $y->[0]) || svcmp([@$x[1..$#{$x}]], [@$y[1..$#{$y}]]); } sub getsv($) { my ($before, $sv, $after) = $_[0] =~ m|^(.+)-([\d.]+)((?:-tests)?\.jar)$| or die "Cannot find semver in $_[0]"; return ([ split /\./, $sv ], "$after$before"); } my @lines = <>; chomp @lines; @lines = sort { my ($asv, $arest) = getsv($a); my ($bsv, $brest) = getsv($b); return ($arest cmp $brest) || svcmp($asv, $bsv); } @lines; for (my $i = 0; $i < @lines; ++$i) { print $lines[$i] if ($i == @lines - 1 || (getsv($lines[$i]))[1] ne (getsv($lines[$i + 1]))[1]); }' < project_names.txt > latest_project_versions.txt
+for dd in $JARS/*/; do d=${dd%/}; echo `grep -F -f <(ls $d|grep '\.jar$') latest_project_versions.txt |wc -l`"   $d"; done | sort -nr > project_versions_successful_builds.txt

--- a/select-project-versions.sh
+++ b/select-project-versions.sh
@@ -6,6 +6,14 @@ then
 	exit 1
 fi
 
-for f in $JARS/*/*.jar; do echo ${f##*/}; done|sort|uniq > project_names.txt
-perl -le 'sub svcmp($$) { my ($x, $y) = @_; return 0 if !@$x && !@$y; return -1 if !@$x; return 1 if !@$y; return ($x->[0] <=> $y->[0]) || svcmp([@$x[1..$#{$x}]], [@$y[1..$#{$y}]]); } sub getsv($) { my ($before, $sv, $after) = $_[0] =~ m|^(.+)-([\d.]+)((?:-tests)?\.jar)$| or die "Cannot find semver in $_[0]"; return ([ split /\./, $sv ], "$after$before"); } my @lines = <>; chomp @lines; @lines = sort { my ($asv, $arest) = getsv($a); my ($bsv, $brest) = getsv($b); return ($arest cmp $brest) || svcmp($asv, $bsv); } @lines; for (my $i = 0; $i < @lines; ++$i) { print $lines[$i] if ($i == @lines - 1 || (getsv($lines[$i]))[1] ne (getsv($lines[$i + 1]))[1]); }' < project_names.txt > latest_project_versions.txt
+if [ -z "$DATASET" ]
+then
+	echo "Must specify the path to the dataset.json file with env var DATASET"
+	exit 1
+fi
+
+#for f in $JARS/*/*.jar; do echo ${f##*/}; done|sort|uniq > project_names.txt
+jq -r '.[] | .name + "\t" + .jar' < "$DATASET" > project_names.txt
+perl -le 'sub svcmp($$) { my ($x, $y) = @_; return 0 if !@$x && !@$y; return -1 if !@$x; return 1 if !@$y; return ($x->[0] <=> $y->[0]) || svcmp([@$x[1..$#{$x}]], [@$y[1..$#{$y}]]); } sub getsv($) { my ($before, $sv, $after) = $_[0] =~ m|^(\S+)\t.+-([\d.]+)((?:-tests)?\.jar)$| or die "Cannot find semver in $_[0]"; return ([ split /\./, $sv ], "$after$before"); } my @lines = <>; chomp @lines; @lines = sort { my ($asv, $arest) = getsv($a); my ($bsv, $brest) = getsv($b); return ($arest cmp $brest) || svcmp($asv, $bsv); } @lines; for (my $i = 0; $i < @lines; ++$i) { print $lines[$i] if ($i == @lines - 1 || (getsv($lines[$i]))[1] ne (getsv($lines[$i + 1]))[1]); }' < project_names.txt > latest_project_versions.txt
+perl -lane 'print $F[1]; $F[1] =~ s|\.jar$|-tests.jar|; print $F[1]' < latest_project_versions.txt > latest_project_versions_with_tests.txt
 for dd in $JARS/*/; do d=${dd%/}; echo `grep -F -f <(ls $d|grep '\.jar$') latest_project_versions.txt |wc -l`"   $d"; done | sort -nr > project_versions_successful_builds.txt


### PR DESCRIPTION
Some quick and dirty scripts to reproduce the NEQ2 oracle and mutated jars uploaded to `dataset`.

MD5 hashes match:
```
wtwhite@wtwhite-vuw-vm:~/code/jmutator-LATER$ JARS=/home/wtwhite/code/jcompile/runs/32_run_31_with_correct_project_names/jars/EQ DATASET=/home/wtwhite/code/jcompile/dataset.json time ./run-all.sh 
--snip--
jars/NEQ2/openjdk-11.0.19/commons-net-3.9.0/
commons-net-3.9.0
jars/NEQ2/openjdk-11.0.19/commons-net-3.9.0-tests/
commons-net-3.9.0-tests
jars/NEQ2/openjdk-11.0.19/json-20230618/
json-20230618
jars/NEQ2/openjdk-11.0.19/original-jackson-core-2.15.2/
original-jackson-core-2.15.2

real	0m56.453s
user	0m58.188s
sys	0m3.714s
1387.28user 40.78system 15:54.84elapsed 149%CPU (0avgtext+0avgdata 985472maxresident)k
352inputs+18693416outputs (422major+3892743minor)pagefaults 0swaps
wtwhite@wtwhite-vuw-vm:~/code/jmutator-LATER$ wc -l ~/code/dataset/NEQ2.tsv 
142896 /home/wtwhite/code/dataset/NEQ2.tsv
wtwhite@wtwhite-vuw-vm:~/code/jmutator-LATER$ md5sum ~/code/dataset/NEQ2.tsv
5ae36e40ec33bb518b9ab46d46ae6ba9  /home/wtwhite/code/dataset/NEQ2.tsv
wtwhite@wtwhite-vuw-vm:~/code/jmutator-LATER$ md5sum NEQ2.tsv
5ae36e40ec33bb518b9ab46d46ae6ba9  NEQ2.tsv
```
