### PR TITLE
Strip initial path component from NEQ2 jar paths

### DIFF
--- a/run-all.sh
+++ b/run-all.sh
@@ -28,4 +28,4 @@ time for d in jars/EQ/$COMPILER/*; do echo $d; m=${d/EQ/NEQ2}; echo $m; mkdir -p
 time ./convert-json-to-tsv-faster.sh > NEQ2.tsv
 
 # Jar up classes
-time for d in jars/NEQ2/$COMPILER/*/; do echo $d; b=`basename ${d%/}`; echo $b; ( cd `dirname $d` && find $b -name '*.class' > $b.filelist && jar --create --file $b.jar @$b.filelist ) ; done
+time for d in jars/NEQ2/$COMPILER/*/; do echo $d; b=`basename ${d%/}`; echo $b; ( cd $d && find * -name '*.class' > ../$b.filelist && jar --create --file ../$b.jar @../$b.filelist ) ; done


### PR DESCRIPTION
Before:
```
wtwhite@wtwhite-vuw-vm:~/code/jmutator$ unzip -l -v old_jars_with_extra_path_component/bcel-6.7.0.jar|head
Archive:  old_jars_with_extra_path_component/bcel-6.7.0.jar
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----
       0  Defl:N        2   0% 2023-12-08 13:17 00000000  META-INF/
      63  Defl:N       62   2% 2023-12-08 13:17 98b68a8e  META-INF/MANIFEST.MF
   29219  Defl:N    11857  59% 2023-12-08 09:59 a9a15294  bcel-6.7.0/org/apache/bcel/Const-2247.class
   29219  Defl:N    11858  59% 2023-12-08 09:59 f68df408  bcel-6.7.0/org/apache/bcel/Const-1407.class
   13354  Defl:N     5378  60% 2023-12-08 09:59 b124ba05  bcel-6.7.0/org/apache/bcel/Constants-67.class
   13354  Defl:N     5375  60% 2023-12-08 09:59 f2b4ba47  bcel-6.7.0/org/apache/bcel/Constants-33.class
   29219  Defl:N    11859  59% 2023-12-08 09:59 d458952c  bcel-6.7.0/org/apache/bcel/Const-1996.class
```

Running it:
```
wtwhite@wtwhite-vuw-vm:~/code/jmutator$ time for d in jars/NEQ2/openjdk-11.0.19/*/; do echo $d; b=`basename ${d%/}`; echo $b; ( cd $d && find * -name '*.class' > ../$b.filelist && jar --create --file ../$b.jar @../$b.filelist ) ; done
jars/NEQ2/openjdk-11.0.19/bcel-6.7.0/
bcel-6.7.0
--snip--
jars/NEQ2/openjdk-11.0.19/commons-net-3.9.0-tests/
commons-net-3.9.0-tests
jars/NEQ2/openjdk-11.0.19/json-20230618/
json-20230618
jars/NEQ2/openjdk-11.0.19/original-jackson-core-2.15.2/
original-jackson-core-2.15.2

real	1m36.639s
user	1m1.374s
sys	0m11.800s
```

After:
```
wtwhite@wtwhite-vuw-vm:~/code/jmutator$ unzip -l -v jars/NEQ2/openjdk-11.0.19/bcel-6.7.0.jar|head
Archive:  jars/NEQ2/openjdk-11.0.19/bcel-6.7.0.jar
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----
       0  Defl:N        2   0% 2024-02-27 18:55 00000000  META-INF/
      57  Defl:N       56   2% 2024-02-27 18:55 08c628f4  META-INF/MANIFEST.MF
   29219  Defl:N    11857  59% 2023-12-08 09:59 a9a15294  org/apache/bcel/Const-2247.class
   29219  Defl:N    11858  59% 2023-12-08 09:59 f68df408  org/apache/bcel/Const-1407.class
   13354  Defl:N     5378  60% 2023-12-08 09:59 b124ba05  org/apache/bcel/Constants-67.class
   13354  Defl:N     5375  60% 2023-12-08 09:59 f2b4ba47  org/apache/bcel/Constants-33.class
   29219  Defl:N    11859  59% 2023-12-08 09:59 d458952c  org/apache/bcel/Const-1996.class
```

Tested by rerunning the final line of `run-all.sh` and eyeballing the resulting jars.
